### PR TITLE
KbnServer is not defined

### DIFF
--- a/server/proxy/init_proxy.js
+++ b/server/proxy/init_proxy.js
@@ -33,7 +33,7 @@ module.exports = function(kbnServer) {
         key: readFileSync(kbnServer.config().get('own_home.ssl.key')),
         cert: readFileSync(kbnServer.config().get('own_home.ssl.certificate')),
 
-        ciphers: KbnServer.config().get('server.ssl.cipherSuites').join(':'),
+        ciphers: kbnServer.config().get('server.ssl.cipherSuites').join(':'),
         // We use the server's cipher order rather than the client's to prevent the BEAST attack
         honorCipherOrder: true
       })


### PR DESCRIPTION
Stack:

ReferenceError: KbnServer is not defined
    at module.exports (/usr/share/kibana/plugins/own_home/server/proxy/init_proxy.js:36:18)
    at ScopedPlugin.init [as externalInit] (/usr/share/kibana/plugins/own_home/index.js:82:9)
    at ScopedPlugin.tryCatcher (/usr/share/kibana/node_modules/bluebird/js/main/util.js:26:23)
    at Promise.attempt.Promise.try (/usr/share/kibana/node_modules/bluebird/js/main/method.js:30:24)
    at /usr/share/kibana/src/server/plugins/plugin.js:169:44
    at undefined.next (native)
    at step (/usr/share/kibana/src/server/plugins/plugin.js:11:273)