### PR TITLE
Set new config parameter ttl of own_home-cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,10 @@ export default function (kibana) {
         session: object({
           secretkey: string().default('the-password-must-be-at-least-32-characters-long'),
           isSecure: boolean().default(true),
-          timeout: number().default(3600000)
+          timeout: number().default(3600000),
+          cookie: object({
+            ttl: number().integer().min(0).default(60 * 60 * 1000)
+          }).default()
         }).default(),
         local: object({
           enabled: boolean().default(true),

--- a/server/proxy/init_proxy.js
+++ b/server/proxy/init_proxy.js
@@ -138,7 +138,8 @@ module.exports = function(kbnServer) {
     cookieOptions: {
       password: kbnServer.config().get('own_home.session.secretkey'),
       isSecure: kbnServer.config().get('own_home.session.isSecure'),
-      passThrough: true
+      passThrough: true,
+      ttl: kbnServer.config().get('own_home.session.cookie.ttl')
     }
   };
 


### PR DESCRIPTION
Hi, 

concerning #66 I found a possible solution. 
In my case it would be nice to make ttl date of the own_home-cookie configurable, so it is possible to keep the cookie after a browser restart.