### PR TITLE
support jwt

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ export default function (kibana) {
           enabled: boolean().default(false),
           key: string().default('username')
         }).default(),
+        jwt: object({
+          enabled: boolean().default(false),
+          userclaim: string().default('email'),
+          verifyurl: string()
+        }).default(),
         default_kibana_index_suffix: string(),
         ssl: object({
           certificate: string(),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "ldapjs": "^1.x.x",
     "yar": "^8.x.x",
     "httpolyglot": "^0.1.2",
-    "kibi-h2o2": "https://github.com/sirensolutions/h2o2.git#5.0.0-kibi-1"
+    "kibi-h2o2": "https://github.com/sirensolutions/h2o2.git#5.0.0-kibi-1",
+    "jsonwebtoken": "8.3.0",
+    "axios": "0.18.0"
   }
 }

--- a/server/get_remote_user/get_from_jwt.js
+++ b/server/get_remote_user/get_from_jwt.js
@@ -1,0 +1,15 @@
+import getJwt from '../jwt/get_jwt';
+import decodeJwt from '../jwt/decode_jwt';
+
+export default function (server, request) {
+  const token = getJwt(request);
+
+  if (token) {
+    const jwtTokenProperty = server.config().get('own_home.jwt.userclaim');
+
+    const jwt = decodeJwt(token);
+    return jwt[jwtTokenProperty];
+  }
+
+  return null;
+}

--- a/server/get_remote_user/index.js
+++ b/server/get_remote_user/index.js
@@ -1,10 +1,13 @@
 import getFromHeader from './get_from_header';
 import getFromSession from './get_from_session';
+import getFromJwt from './get_from_jwt';
 
 export default function (server, request) {
   if (server.config().get('own_home.get_username_from_session.enabled')) {
     return getFromSession(server, request);
-  } else {
+  } else if (server.config().get('own_home.jwt.enabled')) {
+    return getFromJwt(server, request);
+  } {
     return getFromHeader(server, request);
   }
 };

--- a/server/get_remote_user/index.js
+++ b/server/get_remote_user/index.js
@@ -7,7 +7,7 @@ export default function (server, request) {
     return getFromSession(server, request);
   } else if (server.config().get('own_home.jwt.enabled')) {
     return getFromJwt(server, request);
-  } {
+  } else {
     return getFromHeader(server, request);
   }
 };

--- a/server/jwt/decode_jwt.js
+++ b/server/jwt/decode_jwt.js
@@ -1,0 +1,5 @@
+import decode from 'jsonwebtoken/decode';
+
+export default function (token) {
+  return decode(token);
+}

--- a/server/jwt/get_jwt.js
+++ b/server/jwt/get_jwt.js
@@ -1,0 +1,13 @@
+export default function (request) {
+  const authToken = 'authorization';
+
+  if (authToken in request.headers) {
+    const authHeader = request.headers[authToken];
+    const authMethod = authHeader.split(' ')[0].toLowerCase();
+    if (authMethod === 'bearer') {
+      return authHeader.substring(7);
+    }
+  }
+
+  return null;
+}

--- a/server/jwt/verify_jwt.js
+++ b/server/jwt/verify_jwt.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+export default function (server, token, callback, callbackErr) {
+  const url = server.config().get('own_home.jwt.verifyurl');
+
+  function verifyJwt(token) {
+    axios({
+      url: url,
+      headers: {
+        'Authorization': 'Bearer ' + token
+      }
+    })
+      .then(function (response) {
+        server.log(['plugin:own-home', 'debug'], 'Jwt token verified');
+        callback();
+      })
+      .catch(function (error) {
+        server.log(['plugin:own-home', 'error'], 'Jwt verification failure', error);
+        callbackErr(error);
+      });
+  }
+
+  verifyJwt(token);
+}

--- a/server/proxy/map_uri.js
+++ b/server/proxy/map_uri.js
@@ -45,8 +45,8 @@ export default function mapUri(server, mappings) {
     const mappedUrl = formatUrl(mappedUrlComponents);
     server.log(['plugin:own-home', 'debug'], 'mappedUrl: ' + mappedUrl);
 
-    const jwtToken = getJwt(request);
-    if (jwtToken) {
+    if (config.get('own_home.jwt.enabled')) {
+      const jwtToken = getJwt(request);
       verifyJwt(server, jwtToken,
         () => {
           done(null, mappedUrl, request.headers);


### PR DESCRIPTION
This PR aims at supporting JWT Bearer token taken from Authorization header.
To enable it, use `own_home.jwt.enabled`
JWT is decoded and user is taken from a given claim (`own_home.jwt.userclaim`)
Optionaly you can give a url that will verify the token (`own_home.jwt.verifyurl`)