### PR TITLE
Revert "Bump version to 6.6.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ RequestHeader set X-Proxy-User %{REMOTE_USER}s
 * Kibana 6
 
 ```
-bin/kibana-plugin install https://github.com/wtakase/kibana-own-home/releases/download/v6.6.0/own_home-6.6.0.zip
+bin/kibana-plugin install https://github.com/wtakase/kibana-own-home/releases/download/v6.5.4/own_home-6.5.4.zip
 ```
 
 ## Options

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "own_home",
-  "version": "6.6.0",
+  "version": "6.5.4",
   "description": "This plugin adds multi-tenancy feature to Kibana. A user can have own personal kibana.index so that objects the user created are stored in the index. And also group shared kibana.index can be provided. A user can switch kibana.index depending on the situation by selecting on the plugin interface. kibana.index list will be generated based on username, local group definition in kibana.yml, and LDAP roles.",
   "main": "index.js",
   "kibana": {
-    "version": "6.6.0"
+    "version": "6.5.4"
   },
   "scripts": {
     "lint": "eslint",


### PR DESCRIPTION
Reverts wtakase/kibana-own-home#129

The plugin doesn't work with Kibana v6.6.x because of Hapi v17:
https://www.elastic.co/blog/kibana-plugin-api-changes-in-6-6